### PR TITLE
fixed ctid check

### DIFF
--- a/vzrepair.pl
+++ b/vzrepair.pl
@@ -77,7 +77,7 @@ sub main {
     if ( defined $ctid ) {
     
         # correct ctid?
-        if ( $ctid !~ /^\d+$/ ) {
+        if ( $ctid !~ /^\d+\z/ ) {
             debug_print("error", "$ctid is cannot be correct ctid!");
             print_json(qq/{"error_message":"$ctid is cannot be correct ctid!"}/) if $json;
             exit 1;


### PR DESCRIPTION
If ctid parameter contains newline at the end it will pass this check,
so strictly check end of string with \z
